### PR TITLE
umschalten Belichter entfernt

### DIFF
--- a/Einweisung_Platinenaetzer.tex
+++ b/Einweisung_Platinenaetzer.tex
@@ -135,8 +135,7 @@ Beim Belichten wird der Photolack durch UV-Bestrahlung an den Stellen, an denen 
 \item Platine mit Layout im Belichter positionieren: ausreichend Abstand vom Rand des Belichters halten.
 \item Obere Glasscheibe herunterklappen
 \item Belichter einschalten. Warten bis die Druckanzeige beim Enddruck (-0,3 bar) angekommen ist, jetzt ist das Layout an die Platine angedrückt.
-\item Deckel schließen
-\item Rechten Auswahlschalter auf \enquote{nur oben} (einseitige Platinen) bzw. \enquote{oben und unten} (doppelseitige Platinen) stellen. 
+\item Deckel schließen 
 \item Empfohlene Belichtungszeit nachlesen (steht normalerweise beim Belichter auf einem Aufkleber)
 \item Belichtungszeit einstellen: Knopf 1 Schritt drehen, Sekunden-Anzeige blinkt.
 \item Sekunden (Einerstelle) einstellen, Knopf drücken.


### PR DESCRIPTION
Umschalten einseitig/zweiseitig aus der Belichtungsanleitung entfernt.